### PR TITLE
Use `HasUserNamespaces =?= true`

### DIFF
--- a/tests/unit/test_starter.py
+++ b/tests/unit/test_starter.py
@@ -55,7 +55,7 @@ async def test_000(htcs_mock: MagicMock, itsps_mock: AsyncMock) -> None:
             "HAS_CVMFS_icecube_opensciencegrid_org && "
             # "has_avx && has_avx2 && "
             '(OSG_OS_VERSION =?= "8" || OSG_OS_VERSION =?= "9") && '
-            "SingularityUserNamespaces =?= true && "
+            "HasUserNamespaces =?= true && "
             'GLIDEIN_Site =!= "AMNH" && '
             'GLIDEIN_Site =!= "Kansas State University" && '
             'GLIDEIN_Site =!= "NotreDame" && '

--- a/tms/config.py
+++ b/tms/config.py
@@ -21,7 +21,7 @@ _BASE_REQUIREMENTS = [
     #
     # support apptainer-in-apptainer https://github.com/apptainer/apptainer/issues/2167]
     '(OSG_OS_VERSION =?= "8" || OSG_OS_VERSION =?= "9")',
-    "SingularityUserNamespaces =?= true",  # should prevent failures w/ "Failed to create user namespace: user namespace disabled"
+    "HasUserNamespaces =?= true",  # should prevent failures w/ "Failed to create user namespace: user namespace disabled"
 ]
 _EXCLUDED_GLIDEIN_SITES = [
     f'GLIDEIN_Site =!= "{site}"'  # '=!=' -> 'not equal or undefined'


### PR DESCRIPTION
HTCondor folks suggested replacing `SingularityUserNamespaces =?= true` with `HasUserNamespaces =?= true`, as "SingularityUserNamespaces is tested against the singularity that ships with HTCondor, which won't necessarily be the one you are using."

Backstory:

> [The TMS] occasionally will see jobs fail with "Failed to create user namespace: user namespace disabled". So, in response, we added:
> 
> SingularityUserNamespaces =?= true
> 
> And when jobs are matched and run, everything works. However, at times, OSG does not have any slots available that match this additional requirement. When this requirement is removed, slots without "SingularityUserNamespaces" can succeed. So, we're thinking this is not the ideal requirement.
